### PR TITLE
Permit coinbase txs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Python 3.3.3
 
 - sortedcontainers
 - numpy
+- python-bitcoinrpc
 
 
 ## Installation
@@ -37,56 +38,82 @@ python setup.py install
 
 ## Usage
 
-python ludwig.py [--duration=600] [--maxnbtxos=12] [--cjmaxfeeratio=0] [--options=PRECHECK,LINKABILITY,MERGE_FEES,MERGE_INPUTS,MERGE_OUTPUTS] [--txids=8e56317360a548e8ef28ec475878ef70d1371bee3526c017ac22ad61ae5740b8,812bee538bd24d03af7876a77c989b2c236c063a5803c720769fc55222d36b47,...]
+python ludwig.py [--rpc] [--duration=600] [--maxnbtxos=12] [--cjmaxfeeratio=0] [--options=PRECHECK,LINKABILITY,MERGE_FEES,MERGE_INPUTS,MERGE_OUTPUTS] [--txids=8e56317360a548e8ef28ec475878ef70d1371bee3526c017ac22ad61ae5740b8,812bee538bd24d03af7876a77c989b2c236c063a5803c720769fc55222d36b47,...]
 
 [-t OR --txids] = List of txids to be processed.
 
-[-d OR --duration] = Maximum number of seconds allocated to the processing of a single transaction. 
+[-p OR --rpc] = Use bitcoind's RPC interface as source of blockchain data
+
+[-d OR --duration] = Maximum number of seconds allocated to the processing of a single transaction.
                      Default value is 600 seconds.
 
-[-x OR --maxnbtxos] = Maximum number of inputs or ouputs. 
-                      Transactions with more than maxnbtxos inputs or outputs are not processed. 
+[-x OR --maxnbtxos] = Maximum number of inputs or ouputs.
+                      Transactions with more than maxnbtxos inputs or outputs are not processed.
                       Default value is 12.    
 
-[-r OR --cjmaxfeeratio] = Max intrafees paid by the taker of a coinjoined transaction. 
+[-r OR --cjmaxfeeratio] = Max intrafees paid by the taker of a coinjoined transaction.
                           Expressed as a percentage of the coinjoined amount.
 
-[-o OR --options] = Options to be applied during processing. 
+[-o OR --options] = Options to be applied during processing.
                     Default value is PRECHECK, LINKABILITY, MERGE_INPUTS.
                     Available options are :
-                    
+
 - PRECHECK = Checks if deterministic links exist without processing the entropy of the transaction. Similar to Coinjoin Sudoku by K.Atlas.
-                      
+
 - LINKABILITY = Computes the entropy of the transaction and the txos linkability matrix.
-                      
+
 - MERGE_INPUTS = Merges inputs "controlled" by a same address. Speeds up computations.
-                      
+
 - MERGE_OUTPUTS = Merges outputs "controlled" by a same address. Speeds up computations but this option is not recommended.
-                      
+
 - MERGE_FEES = Processes fees as an additional output paid by a single participant. May speed up computations.
 
 
-## Notes
+## Troubleshooting
 
-Boltzmann is provided with a wrapper querying blockchain.info api in order to retrieve data related to transactions. Anyway, it remains possible to develop additional wrappers querying others data sources. A wrapper for bitcoind rpc api is in the pipe.
+This project requires python 3. If your default `python` points to python 2, substitute `python3` for all instructions in this README.
 
+## Data Sources
+
+You can use the remote Blockchain.info API for blockchain data (default), bitcoind's local RPC interface using the `--rpc` command line option, or write your own wrapper.
+
+In order to use bitcoind's RPC interface, you must set these environment variables:
+* BOLTZMANN_RPC_USERNAME
+* BOLTZMANN_RPC_PASSWORD
+* BOLTZMANN_RPC_HOST
+* BOLTZMANN_RPC_PORT
+
+Ex. `$ export BOLTZMANN_RPC_USERNAME=myusername`
+
+You will also need to enable full indexing for bitcoind. This consumes more storage space. See this sample excerpt of a `bitcoin.cfg` file:
+```
+# You must set rpcuser and rpcpassword to secure the JSON-RPC api
+rpcuser=myusername
+rpcpassword=mysecretpassword_REPLACE_ME
+rpcport=8332
+
+#Maintain a full transaction index, used by the getrawtransaction rpc call (default: 0)
+txindex=1
+```
 
 ## Contributors
-@LaurentMT
+@LaurentMT 
 @kristovatlas
 
 
 ## Contributing
-
-Help us to make Boltzmann better !
 
 Many improvements are needed:
  - smarter heuristics to manage intra fees paid/received by participants to coinjoin markets (e.g. joinmarket, ...)
  - optimization of the algorithm (parallelization, memoization, ...)
  - ...
 
+Help us to make Boltzmann better !
+
 1. Fork it
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create new Pull Request
+
+Tip: Don't forget to run `python setup.py clean && python setup.py build && python setup.py install` after modifying source files.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ python ludwig.py [--duration=600] [--maxnbtxos=12] [--cjmaxfeeratio=0] [--option
 
 ## Notes
 
-Boltzmann is provided with a wrapper querying blockchain.info api in order to retrieve data related to transactions. Anyway, it remains possible to develop additional wrappers querying others data sources (e.g. a local bitcoin node, etc).
+Boltzmann is provided with a wrapper querying blockchain.info api in order to retrieve data related to transactions. Anyway, it remains possible to develop additional wrappers querying others data sources. A wrapper for bitcoind rpc api is in the pipe.
 
 
 ## Contributors

--- a/README.md
+++ b/README.md
@@ -2,12 +2,7 @@
 
 A python script computing the entropy of Bitcoin transactions and the linkability of their inputs and outputs.
 
-Initially developed for the OXT platform. 
-
-Certainly, the worst implementation in the world but with a nice property: it exists :)
-
-
-More information at:
+For a description of the metrics :
 
 - Bitcoin Transactions & Privacy (part 1) : https://gist.github.com/LaurentMT/e758767ca4038ac40aaf
 
@@ -73,11 +68,12 @@ python ludwig.py [--duration=600] [--maxnbtxos=12] [--cjmaxfeeratio=0] [--option
 
 ## Notes
 
-Boltzmann is provided with a wrapper querying blockchain.info api in order to retrieve data related to transactions. Anyway, it remains possible to develop additional wrappers querying others data sources (e.g. a local bitcoin node, etc)
+Boltzmann is provided with a wrapper querying blockchain.info api in order to retrieve data related to transactions. Anyway, it remains possible to develop additional wrappers querying others data sources (e.g. a local bitcoin node, etc).
 
 
-## Author
-Twitter: @LaurentMT
+## Contributors
+@LaurentMT
+@kristovatlas
 
 
 ## Contributing

--- a/boltzmann/linker/txos_linker.py
+++ b/boltzmann/linker/txos_linker.py
@@ -223,7 +223,7 @@ class TxosLinker(object):
         for j in range(0, expnt):
             two_exp_j = 2**j
             tmp = np.repeat(base, two_exp_j)
-            all_agg[j, :] = np.tile(tmp, 2**(expnt-1) / two_exp_j)
+            all_agg[j, :] = np.tile(tmp, int(2**(expnt-1) / two_exp_j))
         #all_agg = np.arange(2**expnt) >> np.arange(expnt)[::, np.newaxis] & 1
 
         # Computes values of aggregates

--- a/boltzmann/linker/txos_linker.py
+++ b/boltzmann/linker/txos_linker.py
@@ -12,56 +12,56 @@ from boltzmann.utils.lists import merge_sets
 
 class TxosLinker(object):
     '''
-    A class allowing to compute the entropy of Bitcoin transactions 
+    A class allowing to compute the entropy of Bitcoin transactions
     and the linkability of inputs/outputs of a transaction
-    '''    
-    
+    '''
+
     '''
     CONSTANTS
-    '''   
+    '''
     # Default maximum duration in seconds
     MAX_DURATION = 180
-    
+
     # Processing options
     LINKABILITY = 'LINKABILITY'
     PRECHECK = 'PRECHECK'
     MERGE_FEES = 'MERGE_FEES'
-    
+
     # Markers
     FEES = 'FEES'
     PACK = 'PACK'
-    
+
     # Max number of inputs (or outputs) which can be processed by this algorithm
     MAX_NB_TXOS = 12
-    
-    
-        
+
+
+
     '''
     ATTRIBUTES
-    
+
     # List of input txos expressed as tuples (id, amount)
     inputs = []
-    
+
     # List of output txos expressed as tuples (id, amount)
     outputs = []
-    
+
     # Fees associated to the transaction
     fees = 0
-    
+
     # Matrix of txos linkability
     #    Columns = input txos
     #    Rows = output txos
     #    Cells = number of combinations for which an input and an output are linked
     links = np.array()
-    
+
     # Number of valid transactions combinations
     nb_tx_cmbn = 0
-    
+
     # Maximum duration of the script (in seconds)
     _max_duration = MAX_DURATION
     '''
-    
-    
+
+
     '''
     INITIALIZATION
     '''
@@ -79,13 +79,13 @@ class TxosLinker(object):
         self._orig_outs = outputs
         self._orig_fees = fees
         self._max_duration = max_duration
-        self.max_txos = max_txos        
+        self.max_txos = max_txos
         self._packs = []
-                        
-    
+
+
     '''
     PUBLIC METHODS
-    '''  
+    '''
     def process(self, linked_txos=[], options=[LINKABILITY, PRECHECK], intrafees=(0,0)):
         '''
         Computes the linkability between a set of input txos and a set of output txos
@@ -103,7 +103,7 @@ class TxosLinker(object):
             intrafees       = tuple (fees_maker, fees_taker) of max "fees" paid among participants
                               used for joinmarket transactions
                               fees_maker are potential max "fees" received by a participant from another participant
-                              fees_taker are potential max "fees" paid by a participant to all others participants 
+                              fees_taker are potential max "fees" paid by a participant to all others participants
         '''
         self._options = options
         self.inputs = self._orig_ins.copy()
@@ -111,12 +111,12 @@ class TxosLinker(object):
         self._fees_maker = intrafees[0]
         self._fees_taker = intrafees[1]
         self._has_intrafees = True if (self._fees_maker or self._fees_taker) else False
-        
+
         # Packs txos known as being controlled by a same entity
-        # It decreases the entropy and speeds-up computations 
+        # It decreases the entropy and speeds-up computations
         if linked_txos:
             self._pack_linked_txos(linked_txos)
-        
+
         # Manages fees
         if (self.MERGE_FEES in options) and (self._orig_fees > 0):
             # Manages fees as an additional output (case of sharedsend by blockchain.info).
@@ -126,17 +126,17 @@ class TxosLinker(object):
             self.outputs.append(txo_fees)
         else:
             self._fees = self._orig_fees
-        
+
         # Checks deterministic links
-        nb_cmbn = 0        
+        nb_cmbn = 0
         if self.PRECHECK in options and self._check_limit_ok(self.PRECHECK) and (not self._has_intrafees):
             # Prepares the data
             self._prepare_data()
             self._match_agg_by_val()
             # Checks deterministic links
             dtrm_lnks, dtrm_lnks_id = self._check_dtrm_links()
-            # If deterministic links have been found, fills the linkability matrix 
-            # (returned as result if linkability is not processed) 
+            # If deterministic links have been found, fills the linkability matrix
+            # (returned as result if linkability is not processed)
             if dtrm_lnks is not None:
                 shape = ( len(self.outputs), len(self.inputs) )
                 mat_lnk = np.zeros(shape, dtype=np.int64)
@@ -144,8 +144,8 @@ class TxosLinker(object):
                     mat_lnk[r,c] = 1
         else:
             mat_lnk = None
-            dtrm_lnks_id = None        
-                    
+            dtrm_lnks_id = None
+
         # Checks if all inputs and outputs have already been merged
         nb_ins = len(self.inputs)
         nb_outs = len(self.outputs)
@@ -154,7 +154,7 @@ class TxosLinker(object):
             shape = (nb_outs, nb_ins)
             mat_lnk = np.ones(shape, dtype=np.int64)
         elif self.LINKABILITY in options and self._check_limit_ok(self.LINKABILITY):
-            # Packs deterministic links if needed 
+            # Packs deterministic links if needed
             if dtrm_lnks_id is not None:
                 dtrm_lnks_id = [set(lnk) for lnk in dtrm_lnks_id]
                 self._pack_linked_txos(dtrm_lnks_id)
@@ -165,14 +165,14 @@ class TxosLinker(object):
             self._compute_in_agg_cmbn()
             # Builds the linkability matrix
             nb_cmbn, mat_lnk = self._compute_link_matrix()
-        
+
         # Unpacks the matrix
         mat_lnk = self._unpack_link_matrix(mat_lnk, nb_cmbn)
-        
+
         # Returns results
         return mat_lnk, nb_cmbn, self.inputs, self.outputs
-                                                                             
-        
+
+
     '''
     PREPARATION
     '''
@@ -187,13 +187,13 @@ class TxosLinker(object):
         self.inputs,\
         self._all_in_agg,\
         self._all_in_agg_val = self._prepare_txos(self.inputs)
-           
+
         # Prepares data related to the output txos
         self.outputs,\
         self._all_out_agg,\
         self._all_out_agg_val = self._prepare_txos(self.outputs)
-        
-        
+
+
     def _prepare_txos(self, txos):
         '''
         Computes several data structures related to a list of txos
@@ -206,36 +206,36 @@ class TxosLinker(object):
         '''
         # Removes txos with null value
         txos = filter(lambda x: x[1] > 0, txos)
-        
+
         # Orders txos by value
         txos = sorted(txos, key=lambda tup: tup[1], reverse=True)
-        
+
         # Creates a 1D array of values
         vals = [ e[1] for _, e in enumerate(txos) ]
         all_val = np.array(vals, dtype='int64')
-        
+
         # Computes all possible combinations of txos encoded in binary format
         expnt = len(txos)
         shape = (expnt, 2**expnt)
         all_agg = np.zeros(shape, dtype=np.bool)
         base = np.array([0,1], dtype=bool)
-        
+
         for j in range(0, expnt):
             two_exp_j = 2**j
             tmp = np.repeat(base, two_exp_j)
             all_agg[j, :] = np.tile(tmp, 2**(expnt-1) / two_exp_j)
         #all_agg = np.arange(2**expnt) >> np.arange(expnt)[::, np.newaxis] & 1
-        
+
         # Computes values of aggregates
         all_agg_val = np.dot(all_val, all_agg)
-        
+
         # Returns computed data structures
         return txos, all_agg, all_agg_val
-   
-    
+
+
     '''
     PROCESSING OF AGGREGATES
-    '''  
+    '''
     def _match_agg_by_val(self):
         '''
         Matches input/output aggregates by values and returns a bunch of data structs
@@ -243,24 +243,24 @@ class TxosLinker(object):
         self._all_match_in_agg = SortedList()
         self._match_in_agg_to_val = defaultdict(int)
         self._val_to_match_out_agg = defaultdict(set)
-        
+
         # Gets unique values of input / output aggregates
         all_unique_in_agg_val, _ = np.unique(self._all_in_agg_val, return_inverse=True)
         all_unique_out_agg_val, _ = np.unique(self._all_out_agg_val, return_inverse=True)
-        
+
         # Computes total fees paid/receiver by taker/maker
         if self._has_intrafees:
             fees_taker = self._fees + self._fees_taker
             fees_maker = - self._fees_maker         # doesn't take into account tx fees paid by makers
-        
+
         # Finds input and output aggregates with matching values
         for in_agg_val in np.nditer(all_unique_in_agg_val):
             val = int(in_agg_val)
-            
+
             for out_agg_val in np.nditer(all_unique_out_agg_val):
-                
+
                 diff = in_agg_val - out_agg_val
-                
+
                 if (not self._has_intrafees) and (diff < 0):
                     break
                 else:
@@ -268,80 +268,80 @@ class TxosLinker(object):
                     cond_no_intrafees = (not self._has_intrafees) and diff <= self._fees
                     cond_intrafees = self._has_intrafees and\
                                      ( (diff <= 0 and diff >= fees_maker) or (diff >= 0 and diff <= fees_taker) )
-                                     
+
                     if cond_no_intrafees or cond_intrafees:
                         # Registers the matching input aggregate
                         match_in_agg = np.where(self._all_in_agg_val == in_agg_val)[0]
-                        
+
                         for in_idx in match_in_agg:
                             if not in_idx in self._all_match_in_agg:
                                 self._all_match_in_agg.add(in_idx)
                                 self._match_in_agg_to_val[in_idx] = val
-                        
+
                         # Registers the matching output aggregate
                         match_out_agg = np.where(self._all_out_agg_val == out_agg_val)[0]
                         self._val_to_match_out_agg[val].update(match_out_agg.tolist())
-         
-    
+
+
     def _compute_in_agg_cmbn(self):
         '''
         Computes a matrix of valid combinations (pairs) of input aggregates
         Returns a dictionary (parent_agg => (child_agg1, child_agg2))
         We have a valid combination (agg1, agg2) if:
            R1/ child_agg1 & child_agg2 = 0 (no bitwise overlap)
-           R2/ child_agg1 > child_agg2 (matrix is symmetric)           
+           R2/ child_agg1 > child_agg2 (matrix is symmetric)
         '''
         aggs = self._all_match_in_agg[1:-1]
         tgt = self._all_match_in_agg[-1]
         mat = defaultdict(list)
         saggs = set(aggs)
-        
+
         for i in range(0, tgt+1):
             if i in saggs:
                 j_max = min(i, tgt - i + 1)
                 for j in range(0, j_max):
                     if (i & j == 0) and (j in saggs):
                         mat[i+j].append( (i,j) )
-        
+
         self._mat_in_agg_cmbn = mat
-    
-    
+
+
     '''
     COMPUTATION OF LINKS BETWEEN TXOS
     '''
-    def _check_dtrm_links(self):    
+    def _check_dtrm_links(self):
         '''
         Checks the existence of deterministic links between inputs and outputs
         Returns a list of tuples (idx_output, idx_input) and a list of tuples (id_output, id_input)
         '''
         nb_ins = len(self.inputs)
         nb_outs = len(self.outputs)
-        
+
         shape = (nb_outs, nb_ins)
         mat_cmbn = np.zeros(shape, dtype=np.int64)
-        
+
         shape = (1, nb_ins)
         in_cmbn = np.zeros(shape, dtype=np.int64)
-        
+
         # Computes a matrix storing numbers of raw combinations matching input/output pairs
         # Also computes sum of combinations along inputs axis to get the number of combinations
         for (in_idx, val) in self._match_in_agg_to_val.items():
             for out_idx in self._val_to_match_out_agg[val]:
                 mat_cmbn += self._get_link_cmbn(in_idx, out_idx)
-                in_cmbn += self._all_in_agg[:,in_idx][np.newaxis,:]                       
-        
+                in_cmbn += self._all_in_agg[:,in_idx][np.newaxis,:]
+
         # Builds a list of sets storing inputs having a deterministic link with an output
         nb_cmbn = in_cmbn[0,0]
         dtrm_rows, dtrm_cols = np.where(mat_cmbn == nb_cmbn)
         dtrm_coords = list(zip(dtrm_rows, dtrm_cols))
         dtrm_aggs = [(self.outputs[o][0], self.inputs[i][0]) for (o,i) in dtrm_coords]
         return dtrm_coords, dtrm_aggs
-        
-                
+
+
     def _compute_link_matrix(self):
         '''
         Computes the linkability matrix
-        Returns the number of possible combinations and the links matrix        
+        Returns the number of possible combinations and the links matrix
         Implements a depth-first traversal of the inputs combinations tree (right to left)
         For each input combination we compute the matching output combinations.
         This is a basic brute-force solution. Will have to find a better method later.
@@ -350,7 +350,7 @@ class TxosLinker(object):
         itgt = 2 ** len(self.inputs) - 1
         otgt = 2 ** len(self.outputs) - 1
         d_links = defaultdict(int)
-        
+
         # Initializes a stack of tasks & sets the initial task
         #  0: index used to resume the processing of the task (required for depth-first algorithm)
         #  1: il = left input aggregate
@@ -361,10 +361,10 @@ class TxosLinker(object):
         ini_d_out = defaultdict(dict)
         ini_d_out[otgt] = { 0: (1, 0) }
         stack.append( (0, 0, itgt, ini_d_out) )
-        
+
         # Sets start date/hour
         start_time = datetime.now()
-        
+
         # Iterates over all valid inputs combinations (top->down)
         while len(stack) > 0:
             # Checks duration
@@ -372,7 +372,7 @@ class TxosLinker(object):
             delta_time = curr_time - start_time
             if delta_time.total_seconds() >= self._max_duration:
                 return 0, None
-            
+
             # Gets data from task
             t = stack[-1]
             idx_il = t[0]
@@ -380,78 +380,78 @@ class TxosLinker(object):
             ir = t[2]
             d_out = t[3]
             n_idx_il = idx_il
-            
+
             # Gets all valid decompositions of right input aggregate
             ircs = self._mat_in_agg_cmbn[ir]
-            len_ircs = len(ircs)            
-            
+            len_ircs = len(ircs)
+
             for i in range(idx_il, len_ircs):
-                
-                n_idx_il = i                
+
+                n_idx_il = i
                 n_d_out = defaultdict(dict)
-                
+
                 # Gets left input sub-aggregate (column from ircs)
                 n_il = ircs[i][1]
-                
+
                 # Checks if we must process this pair (columns from ircs are sorted in decreasing order)
                 if n_il > il:
                     # Gets the right input sub-aggregate (row from ircs)
                     n_ir = ircs[i][0]
-                    
+
                     # Iterates over outputs combinations previously found
                     for o_r in d_out:
                         sol = otgt - o_r
                         # Computes the number of parent combinations
                         nb_prt = sum([s[0] for s in d_out[o_r].values()])
-                    
+
                         # Iterates over output sub-aggregates matching with left input sub-aggregate
                         val_il = self._match_in_agg_to_val[n_il]
                         for n_ol in self._val_to_match_out_agg[val_il]:
-                            
+
                             # Checks compatibility of output sub-aggregate with left part of output combination
                             if (sol & n_ol == 0):
                                 # Computes:
                                 #   the sum corresponding to the left part of the output combination
                                 #   the complementary right output sub-aggregate
                                 n_sol = sol + n_ol
-                                n_or = otgt - n_sol                                
+                                n_or = otgt - n_sol
                                 # Checks if the right output sub-aggregate is valid
                                 val_ir = self._match_in_agg_to_val[n_ir]
                                 match_out_agg = self._val_to_match_out_agg[val_ir]
                                 # Adds this output combination into n_d_out if all conditions met
                                 if (n_sol & n_or == 0) and (n_or in match_out_agg):
                                     n_d_out[n_or][n_ol] = (nb_prt, 0)
-                                    
+
                     # Updates idx_il for the current task
                     stack[-1] = (i + 1, il, ir, d_out)
                     # Pushes a new task which will decompose the right input aggregate
                     stack.append( (0, n_il, n_ir, n_d_out) )
                     # Executes the new task (depth-first)
                     break
-                
+
                 else:
                     # No more results for il, triggers a break and a pop
                     n_idx_il = len_ircs
                     break
-                
-            # Checks if task has completed     
+
+            # Checks if task has completed
             if n_idx_il > len_ircs - 1:
                 # Pops the current task
                 t = stack.pop()
                 il = t[1]
                 ir = t[2]
                 d_out = t[3]
-                
+
                 # Checks if it's the root task
                 if len(stack) == 0:
                     # Retrieves the number of combinations from root task
                     nb_tx_cmbn = d_out[otgt][0][1]
-                
+
                 else:
                     # Gets parent task
                     p_t = stack[-1]
                     p_d_out = p_t[3]
-                
+
                     # Iterates over all entries from d_out
                     for (o_r, l_ol) in d_out.items():
                         r_key = (ir, o_r)
@@ -467,16 +467,16 @@ class TxosLinker(object):
                             p_l_ol = p_d_out[p_or]
                             for (p_ol, (p_nb_prt, p_nb_chld)) in p_l_ol.items():
                                 p_d_out[p_or][p_ol] = (p_nb_prt, p_nb_chld + nb_occur)
-        
+
         # Fills the matrix
         links = self._get_link_cmbn(itgt, otgt)
         nb_tx_cmbn += 1
         for (lnk, mult) in d_links.items():
             links = links + self._get_link_cmbn(lnk[0], lnk[1]) * mult
-        
+
         return nb_tx_cmbn, links
-    
-    
+
+
     def _get_link_cmbn(self, in_agg, out_agg):
         '''
         Computes a linkability matrix encoding the matching of given input/output aggregates
@@ -487,9 +487,9 @@ class TxosLinker(object):
         '''
         vouts = self._all_out_agg[:,out_agg][:,np.newaxis]
         vins = self._all_in_agg[:,in_agg][np.newaxis,:]
-        return np.dot(vouts, vins)        
-    
-    
+        return np.dot(vouts, vins)
+
+
     '''
     PACKING/UNPACKING OF LINKED TXOS
     '''
@@ -500,19 +500,19 @@ class TxosLinker(object):
             linked_txos = list of sets storing linked input txos. Each txo is identified by its "id"
         '''
         idx = len(self._packs)
-         
+
         # Merges packs sharing common elements
         packs = merge_sets(linked_txos)
-         
+
         for pack in packs:
             ins = []
             val_ins = 0
-             
+
             for i in self.inputs:
                 if i[0] in pack:
                     ins.append(i)
                     val_ins += i[1]
-                     
+
             idx += 1
             if len(ins) > 0:
                 lbl = '%s_I%i' % (self.PACK, idx)
@@ -521,8 +521,8 @@ class TxosLinker(object):
                 in_pack = (lbl, val_ins, 'INPUTS', ins, [])
                 self._packs.append(in_pack)
                 [self.inputs.remove(v) for v in ins]
-            
-    
+
+
     def _unpack_link_matrix(self, mat_lnk, nb_cmbn):
         '''
         Unpacks linked txos in the linkability matrix
@@ -533,9 +533,9 @@ class TxosLinker(object):
         '''
         mat_res = mat_lnk
         nb_cmbn = max(1, nb_cmbn)
-                        
+
         for (pack, val, lctn, ins, outs) in reversed(self._packs):
-            
+
             if lctn == 'INPUTS':
                 key = (pack, val)
                 idx = self.inputs.index(key)
@@ -549,7 +549,7 @@ class TxosLinker(object):
                     mat_res = np.hstack( (mat_res[:,0:idx], vals, mat_res[:,idx+1:]) )
                 # Inserts unpacked inputs into the list of inputs
                 self.inputs[idx:idx+1] = ins
-                  
+
             elif lctn == 'OUTPUTS':
                 key = (pack, val)
                 idx = self.outputs.index(key)
@@ -563,10 +563,10 @@ class TxosLinker(object):
                     mat_res = np.vstack( (mat_res[0:idx,:], vals, mat_res[idx+1:,:]) )
                 # Inserts unpacked outputs into the list of outputs
                 self.outputs[idx:idx+1] = outs
-                
+
         return mat_res
 
-    
+
     '''
     LIMITS
     '''
@@ -575,4 +575,3 @@ class TxosLinker(object):
         len_out = len(self.outputs)
         max_card = max(len_in, len_out)
         return True if (max_card <= self.max_txos) else False
-    

--- a/boltzmann/ludwig.py
+++ b/boltzmann/ludwig.py
@@ -11,7 +11,9 @@ import sys
 sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "/../")
 
 from boltzmann.utils.tx_processor import process_tx
+from boltzmann.utils.bitcoind_rpc_wrapper import BitcoindRPCWrapper
 from boltzmann.utils.bci_wrapper import BlockchainInfoWrapper
+
 
 
 
@@ -25,20 +27,20 @@ def display_results(mat_lnk, nb_cmbn, inputs, outputs, fees, intrafees):
         inputs    = list of input txos (tuples (address, amount))
         outputs   = list of output txos (tuples (address, amount))
         fees      = fees associated to this transaction
-        intrafees = max intrafees paid/received by participants (tuple (max intrafees received, max intrafees paid))         
+        intrafees = max intrafees paid/received by participants (tuple (max intrafees received, max intrafees paid))
     '''
     print('\nInputs = ' + str(inputs))
     print('\nOutputs = ' + str(outputs))
     print('\nFees = %i satoshis' % fees)
-    
+
     if (intrafees[0] > 0) and (intrafees[1] > 0):
         print('\nHypothesis: Max intrafees received by a participant = %i satoshis' % intrafees[0])
         print('Hypothesis: Max intrafees paid by a participant = %i satoshis' % intrafees[1])
-    
+
     print('\nNb combinations = %i' % nb_cmbn)
     if nb_cmbn > 0:
         print('Tx entropy = %f bits' % math.log2(nb_cmbn))
-    
+
     if mat_lnk is None:
         if nb_cmbn == 0:
             print('\nSkipped processing of this transaction (too many inputs and/or outputs)')
@@ -49,66 +51,77 @@ def display_results(mat_lnk, nb_cmbn, inputs, outputs, fees, intrafees):
         else:
             print('\nLinkability Matrix (#combinations with link) :')
             print(mat_lnk)
-        
+
         print('\nDeterministic links :')
         for i in range(0, len(outputs)):
             for j in range(0, len(inputs)):
                 if (mat_lnk[i,j] == nb_cmbn) and mat_lnk[i,j] != 0 :
                     print('%s & %s are deterministically linked' % (inputs[j], outputs[i]))
-    
 
 
 
-def main(txids, options=['PRECHECK', 'LINKABILITY', 'MERGE_INPUTS'], max_duration=600, max_txos=12, max_cj_intrafees_ratio=0):
+
+def main(txids, rpc, options=['PRECHECK', 'LINKABILITY', 'MERGE_INPUTS'], max_duration=600, max_txos=12, max_cj_intrafees_ratio=0):
     '''
     Main function
     Parameters:
         txids                   = list of transactions txids to be processed
+        rpc                     = use bitcoind's RPC interface (or blockchain.info web API)
         options                 = options to be applied during processing
         max_duration            = max duration allocated to processing of a single tx (in seconds)
         max_txos                = max number of txos. Txs with more than max_txos inputs or outputs are not processed.
-        max_cj_intrafees_ratio  = max intrafees paid by the taker of a coinjoined transaction. 
+        max_cj_intrafees_ratio  = max intrafees paid by the taker of a coinjoined transaction.
                                   Expressed as a percentage of the coinjoined amount.
     '''
-    # Initializes the wrapper for bci api
-    bci_wrapper = BlockchainInfoWrapper()
-    
+    blockchain_provider = None
+    provider_descriptor = ''
+    if rpc:
+        blockchain_provider = BitcoindRPCWrapper()
+        provider_descriptor = 'local RPC interface'
+    else:
+        blockchain_provider = BlockchainInfoWrapper()
+        provider_descriptor = 'remove blockchain.info API'
+
+    print("DEBUG: Using %s" % provider_descriptor)
+
     for txid in txids:
         print('\n\n--- %s -------------------------------------' % txid)
-        # Retrieves the tx from bci
+        # Retrieves the tx from local RPC or bci
         try:
-            tx = bci_wrapper.get_tx(txid)
-        except:
-            print('Unable to retrieve information for %s from bc.i' % txid)
+            tx = blockchain_provider.get_tx(txid)
+            print("DEBUG: Tx fetched: {0}".format(str(tx)))
+        except Exception as err:
+            print('Unable to retrieve information for %s from %s: %s' % (txid, provider_descriptor, err))
             continue
-        
+
         # Computes the entropy of the tx and the linkability of txos
         (mat_lnk, nb_cmbn, inputs, outputs, fees, intrafees) = process_tx(tx, options, max_duration, max_txos, max_cj_intrafees_ratio)
-        
+
         # Displays the results
         display_results(mat_lnk, nb_cmbn, inputs, outputs, fees, intrafees)
-        
-    
+
+
 
 def usage():
     '''
     Usage message for this module
     '''
-    sys.stdout.write('python ludwig.py [--duration=600] [--maxnbtxos=12] [--cjmaxfeeratio=0] [--options=PRECHECK,LINKABILITY,MERGE_FEES,MERGE_INPUTS,MERGE_OUTPUTS] [--txids=8e56317360a548e8ef28ec475878ef70d1371bee3526c017ac22ad61ae5740b8,812bee538bd24d03af7876a77c989b2c236c063a5803c720769fc55222d36b47,...]');
+    sys.stdout.write('python ludwig.py [--rpc] [--duration=600] [--maxnbtxos=12] [--cjmaxfeeratio=0] [--options=PRECHECK,LINKABILITY,MERGE_FEES,MERGE_INPUTS,MERGE_OUTPUTS] [--txids=8e56317360a548e8ef28ec475878ef70d1371bee3526c017ac22ad61ae5740b8,812bee538bd24d03af7876a77c989b2c236c063a5803c720769fc55222d36b47,...]');
     sys.stdout.write('\n\n[-t OR --txids] = List of txids to be processed.')
+    sys.stdout.write('\n\n[-p OR --rpc] = Use bitcoind\'s RPC interface as source of blockchain data')
     sys.stdout.write('\n\n[-d OR --duration] = Maximum number of seconds allocated to the processing of a single transaction. Default value is 600')
     sys.stdout.write('\n\n[-x OR --maxnbtxos] = Maximum number of inputs or ouputs. Transactions with more than maxnbtxos inputs or outputs are not processed. Default value is 12.')
     sys.stdout.write('\n\n[-r OR --cjmaxfeeratio] = Max intrafees paid by the taker of a coinjoined transaction. Expressed as a percentage of the coinjoined amount. Default value is 0.')
-    
+
     sys.stdout.write('\n\n[-o OR --options] = Options to be applied during processing. Default value is PRECHECK, LINKABILITY, MERGE_INPUTS')
-    sys.stdout.write('\n    Available options are :')    
+    sys.stdout.write('\n    Available options are :')
     sys.stdout.write('\n    PRECHECK = Checks if deterministic links exist without processing the entropy of the transaction. Similar to Coinjoin Sudoku by K.Atlas.')
     sys.stdout.write('\n    LINKABILITY = Computes the entropy of the transaction and the txos linkability matrix.')
     sys.stdout.write('\n    MERGE_INPUTS = Merges inputs "controlled" by a same address. Speeds up computations.')
     sys.stdout.write('\n    MERGE_OUTPUTS = Merges outputs "controlled" by a same address. Speeds up computations but this option is not recommended.')
     sys.stdout.write('\n    MERGE_FEES = Processes fees as an additional output paid by a single participant. May speed up computations.')
     sys.stdout.flush()
-    
+
 
 if __name__ == '__main__':
     # Initializes parameters
@@ -119,15 +132,18 @@ if __name__ == '__main__':
     options = ['PRECHECK', 'LINKABILITY', 'MERGE_INPUTS']
     argv = sys.argv[1:]
     # Processes arguments
-    try:                                
-        opts, args = getopt.getopt(argv, 'ht:d:o:r:x:', ['help', 'txids=', 'duration=', 'options=', 'cjmaxfeeratio=', 'maxnbtxos='])
-    except getopt.GetoptError:          
-        usage()                         
-        sys.exit(2)                     
+    try:
+        opts, args = getopt.getopt(argv, 'hpt:p:d:o:r:x:', ['help', 'rpc', 'txids=', 'duration=', 'options=', 'cjmaxfeeratio=', 'maxnbtxos='])
+    except getopt.GetoptError:
+        usage()
+        sys.exit(2)
+    rpc = False
     for opt, arg in opts:
         if opt in ('-h', '--help'):
-            usage()                     
+            usage()
             sys.exit()
+        elif opt in ('-p', '--rpc'):
+            rpc = True
         elif opt in ('-d', '--duration'):
             max_duration = int(arg)
         elif opt in ('-x', '--maxnbtxos'):
@@ -139,5 +155,4 @@ if __name__ == '__main__':
         elif opt in ('-o', '--options'):
             options = [t.strip() for t in arg.split(',')]
     # Processes computations
-    main(txids, options, max_duration, max_txos, max_cj_intrafees_ratio)  
-    
+    main(txids=txids, rpc=rpc, options=options, max_duration=max_duration, max_txos=max_txos, max_cj_intrafees_ratio=max_cj_intrafees_ratio)

--- a/boltzmann/ludwig.py
+++ b/boltzmann/ludwig.py
@@ -80,7 +80,7 @@ def main(txids, rpc, options=['PRECHECK', 'LINKABILITY', 'MERGE_INPUTS'], max_du
         provider_descriptor = 'local RPC interface'
     else:
         blockchain_provider = BlockchainInfoWrapper()
-        provider_descriptor = 'remove blockchain.info API'
+        provider_descriptor = 'remote blockchain.info API'
 
     print("DEBUG: Using %s" % provider_descriptor)
 

--- a/boltzmann/tests/blockchain_consistency.py
+++ b/boltzmann/tests/blockchain_consistency.py
@@ -1,0 +1,165 @@
+"""Verifies that all providers of blockchain data are consistent with others."""
+import unittest
+try:
+    from boltzmann.utils.bitcoind_rpc_wrapper import BitcoindRPCWrapper
+    from boltzmann.utils.bci_wrapper import BlockchainInfoWrapper
+except ImportError:
+    import sys
+    import os
+    # Adds boltzmann directory into path
+    sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "/../../")
+    from boltzmann.utils.bitcoind_rpc_wrapper import BitcoindRPCWrapper
+    from boltzmann.utils.bci_wrapper import BlockchainInfoWrapper
+
+
+class CompareTest(unittest.TestCase):
+    """Compare the results of various providers for given transaction IDs."""
+
+    PROVIDERS = [BitcoindRPCWrapper, BlockchainInfoWrapper]
+
+    #a list of transactions with expected data
+    TEST_TXS = [
+        {'height': 100001,
+         'time': 1293624404,
+         'txid': '8131ffb0a2c945ecaf9b9063e59558784f9c3a74741ce6ae2a18d0571dac15bb',
+         'inputs': [{'n': 0,
+                     'value': 5000000000,
+                     'address': '1HYAekgNKqQiCadt3fnKdLQFFNLFHPPnCR',
+                     'tx_idx': 239354,
+                     'script': '4104cd31654088e472c60ab1c6ee7743deb186dce0b1ad5fc45691d37dad2620128e4b33c7c9c19ed01a5817e6e54c12fe1b83eafcb830440f23a2ce903cdb1df52fac'
+                    },
+                    {'n': 0,
+                     'value': 5000000000,
+                     'address': '16hwoJvz1xje8HBgoLZcxwo1CwE3cvkb17',
+                     'tx_idx': 239356,
+                     'script': '41041e1f1bdccf8cd5b9d3ffc0a14a36ad8a97663f14d16b94104d073abfc693d04178f263495cd6037aed097175297b39cfe5f5b9706fd425795bf7f61108145b53ac'
+                    },
+                    {'n': 0,
+                     'value': 5000000000,
+                     'address': '1KWGBfAsuBFzKQ7bhSJV5WbgVNvvQ5R1j2',
+                     'tx_idx': 239322,
+                     'script': '41043ea537ed214d2bcb07f56d2ecb047a4bd11d13fa160856f84e77e8d31ab2154cd2eb8cad37747b50b0b04d739186058d64212368202d1b41bc44fcb6decb90eaac'
+                    },
+                    {'n': 0,
+                     'value': 5000000000,
+                     'address': '15XgnazTwLj7sNPkbUo5vCSKBmR43X5vW4',
+                     'tx_idx': 239205,
+                     'script': '4104b2424b051a79a55b9f7970ceeecb25e81b876c53d9e46d6ee7e0ae656b94f8cf3a27a1b3f2465ac19409e2a08fb7d1f549adc70a5f90ff8418061688186064f4ac'
+                    },
+                    {'n': 0,
+                     'value': 5001000000,
+                     'address': '16HjHvF5umsgAzaX2ddosB81ttkrVHkvqo',
+                     'tx_idx': 239162,
+                     'script': '4104a7d578da4514a14b08d1e939924efaeacfde7d7d2897f2cef87248aaa4e3cd226f0660b9bf759448f9fb2f586f6027667b73d34a8114186265f9364193599c2cac'
+                    }],
+         'outputs': [{'n': 0,
+                      'value': 25000000000,
+                      'address': '15xif4SjXiFi3NDEsmMZCfTdE9jvvVQrjU',
+                      'tx_idx': 240051,
+                      'script': '76a914366a27645806e817a6cd40bc869bdad92fe5509188ac'
+                     },
+                     {'n': 1,
+                      'value': 1000000,
+                      'address': '1NkKLMgbSjXrT7oHagnGmYFhXAWXjJsKCj',
+                      'tx_idx': 240051,
+                      'script': '76a914ee8bd501094a7d5ca318da2506de35e1cb025ddc88ac'
+                     }]
+        },
+        {'height': 299173,
+         'time': 1399267359,
+         'txid': '8e56317360a548e8ef28ec475878ef70d1371bee3526c017ac22ad61ae5740b8',
+         'inputs': [{'n': 0,
+                     'value': 10000000,
+                     'address': '1FJNUgMPRyBx6ahPmsH6jiYZHDWBPEHfU7',
+                     'tx_idx': 55795695,
+                     'script': '76a9149cdac2b6a77e536f5f4ab6518fb078861f4dbf5188ac',
+                    },
+                    {'n': 1,
+                     'value': 1380000,
+                     'address': '1JDHTo412L9RCtuGbYw4MBeL1xn7ZTuzLH',
+                     'tx_idx': 55462552,
+                     'script': '76a914bcccdf22a567d2c30762c2c44edd3d4ff40e944c88ac'
+                    }],
+         'outputs': [{'n': 0,
+                      'value': 100000,
+                      'address': '1JR3x2xNfeFicqJcvzz1gkEhHEewJBb5Zb',
+                      'tx_idx': 55819527,
+                      'script': '76a914bf06953ec3c533d040929dc82eb4845ec0d8171088ac'
+                     },
+                     {'n': 1,
+                      'value': 9850000,
+                      'address': '18JNSFk8eRZcM8RdqLDSgCiipgnfAYsFef',
+                      'tx_idx': 55819527,
+                      'script': '76a9145011d8607971901c1135c2e8ae3074c472af4bf188ac'
+                     },
+                     {'n': 2,
+                      'value': 100000,
+                      'address': '1ALKUqxRb2MeFqomLCqeYwDZK6FvLNnP3H',
+                      'tx_idx': 55819527,
+                      'script': '76a91466607632dc9e3c0ed2e24fe3c54ea488408e99f588ac'
+                     },
+                     {'n': 3,
+                      'value': 1270000,
+                      'address': '1PA1eHufj8axDWEbYfPtL8HXfA66gTFsFc',
+                      'tx_idx': 55819527,
+                      'script': '76a914f3070c305b4bca72aa4b57bcbad05de5a692f16a88ac'
+                     }
+                    ]
+        }]
+    '''
+        TODO:Both of these currently raise exception for BCI, so shouldnt work for RPC either
+        { #genesis block coinbase tx
+            'height': 0,
+            'time': 1231006505,
+            'txid': '4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b',
+            'inputs': [{}], #TODO
+            'outputs': [{}] #TODO
+        },
+        { #BIP30 duplicate tx, see:
+          #https://github.com/kristovatlas/interesting-bitcoin-data
+            'height': 91842, #also height 91812
+            'time': 1289757588,
+            'txid': 'd5d27987d2a3dfc724e359870c6644b40e497bdc0589a033220fe15429d88599',
+            'inputs': [{}], #TODO
+            'outputs': [{}] #TODO
+        }
+    '''
+
+    def test(self):
+        """Verify that fields are present and as expected for each data provider."""
+        for test_idx, expected_tx in enumerate(self.TEST_TXS):
+            for provider in self.PROVIDERS:
+                prov = provider()
+                print("Starting test # {0}".format(test_idx+1))
+                txn = prov.get_tx(expected_tx['txid'])
+                _assertEq(expected_tx['txid'], txn.txid, test_idx+1)
+                _assertNoneOrEqual(txn.time, expected_tx['time'], test_idx+1)
+                _assertEq(
+                    len(expected_tx['inputs']), len(txn.inputs), test_idx+1)
+                _assertEq(
+                    len(expected_tx['outputs']), len(txn.outputs), test_idx+1)
+                for idx, tx_in in enumerate(expected_tx['inputs']):
+                    _assertEq(tx_in['n'], txn.inputs[idx].n, test_idx+1)
+                    _assertEq(tx_in['value'], txn.inputs[idx].value, test_idx+1)
+                    _assertEq(
+                        tx_in['address'], txn.inputs[idx].address, test_idx+1)
+                    _assertNoneOrEqual(
+                        txn.inputs[idx].tx_idx, tx_in['tx_idx'], test_idx+1)
+                for idx, tx_out in enumerate(expected_tx['outputs']):
+                    _assertEq(tx_out['n'], txn.outputs[idx].n, test_idx+1)
+                    _assertEq(
+                        tx_out['value'], txn.outputs[idx].value, test_idx+1)
+                    _assertEq(
+                        tx_out['address'], txn.outputs[idx].address, test_idx+1)
+                    _assertNoneOrEqual(
+                        txn.outputs[idx].tx_idx, tx_out['tx_idx'], test_idx+1)
+
+def _assertEq(a, b, test_num):
+    assert a == b, "Test {0}: {1} != {2}".format(test_num, a, b)
+
+def _assertNoneOrEqual(a, b, test_num):
+    assert a is None or a == b, \
+        "Test {0}: {1} != None && != {2}".format(test_num, a, b)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/boltzmann/tests/tests.py
+++ b/boltzmann/tests/tests.py
@@ -96,6 +96,24 @@ def build_test_vectors():
     outputs = [ ('A', 5), ('B', 5), ('C', 5), ('D', 5), ('E', 5) ]
     test_vectors.append((name, inputs, outputs, options))
     
+    # Test case P6 
+    name = 'TEST P6'
+    inputs  = [ ('a', 5), ('b', 5), ('c', 5), ('d', 5), ('e', 5), ('f', 5) ]
+    outputs = [ ('A', 5), ('B', 5), ('C', 5), ('D', 5), ('E', 5), ('F', 5) ]
+    test_vectors.append((name, inputs, outputs, options))
+    
+    # Test case P7 
+    name = 'TEST P7'
+    inputs  = [ ('a', 5), ('b', 5), ('c', 5), ('d', 5), ('e', 5), ('f', 5), ('g', 5) ]
+    outputs = [ ('A', 5), ('B', 5), ('C', 5), ('D', 5), ('E', 5), ('F', 5), ('G', 5) ]
+    test_vectors.append((name, inputs, outputs, options))
+    
+    # Test case P8 
+    name = 'TEST P8'
+    inputs  = [ ('a', 5), ('b', 5), ('c', 5), ('d', 5), ('e', 5), ('f', 5), ('g', 5), ('h', 5) ]
+    outputs = [ ('A', 5), ('B', 5), ('C', 5), ('D', 5), ('E', 5), ('F', 5), ('G', 5), ('H', 5) ]
+    test_vectors.append((name, inputs, outputs, options))
+    
     # Test case P9 
     name = 'TEST P9'
     inputs  = [ ('a', 5), ('b', 5), ('c', 5), ('d', 5), ('e', 5), ('f', 5), ('g', 5), ('h', 5), ('i', 5) ]

--- a/boltzmann/utils/bci_wrapper.py
+++ b/boltzmann/utils/bci_wrapper.py
@@ -7,33 +7,33 @@ import json
 from urllib.request import urlopen
 from urllib.error import HTTPError
 from boltzmann.utils.transaction import Transaction
+from boltzmann.utils.blockchain_data_wrapper import BlockchainDataWrapper
 
 
-class BlockchainInfoWrapper(object):
+class BlockchainInfoWrapper(BlockchainDataWrapper):
     '''
     A wrapper for blockchain.info api
-    '''   
-    
-    
+    '''
+
+
     '''
     CONSTANTS
-    ''' 
+    '''
     # API base uri
     BASE_URI = "https://blockchain.info/"
-    
+
     # Timeout
     TIMEOUT = 10
 
-    
+
     def get_tx(self, txid):
         response = ''
-        
+
         try:
             uri = self.BASE_URI + 'rawtx/' + txid
             response = urlopen(uri, None, timeout=self.TIMEOUT).read().decode('utf-8')
         except HTTPError as e:
             raise Exception(e.read(), e.code)
-                
+
         json_response = json.loads(response)
         return Transaction(json_response)
-

--- a/boltzmann/utils/bitcoind_rpc_wrapper.py
+++ b/boltzmann/utils/bitcoind_rpc_wrapper.py
@@ -1,0 +1,280 @@
+'''
+Fetch the bare minimum data from bitcoind RPC required to be compatible.
+Created on 20170124
+@author: kristovatlas
+'''
+import os
+import decimal
+from warnings import warn
+from bitcoinrpc.authproxy import AuthServiceProxy
+from boltzmann.utils.transaction import Transaction
+from boltzmann.utils.blockchain_data_wrapper import BlockchainDataWrapper
+
+class MissingRPCConfigurationError(Exception):
+    """Configuration for RPC connection is missing."""
+    def __init__(self, msg):
+        self.msg = msg
+        super(MissingRPCConfigurationError, self).__init__()
+
+    def __str__(self):
+        return "MissingRPCConfigurationError with {0}".format(self.msg)
+
+
+class NoDataAvailableForGenesisBlockError(Exception):
+    """No data available for the genesis block from bitcoind.
+
+    If the requested tx is the sole transaction of the genesis block, bitcoind's
+    RPC interface will throw an error 'No information available about
+    transaction (code -5)'
+    """
+    pass
+
+
+class PrevOutAddressCannotBeDecodedError(Exception):
+    """Raised when a previous transaction's output address can't be decoded by RPC."""
+    def __init__(self, msg):
+        self.msg = msg
+        super(PrevOutAddressCannotBeDecodedError, self).__init__()
+
+    def __str__(self):
+        return "PrevOutAddressCannotBeDecodedError with {0}".format(self.msg)
+
+
+class BitcoindRPCWrapper(BlockchainDataWrapper):
+    '''
+    A connection manager for bitcoind's RPC interface
+
+    All RPC configuration variables will be set using the following env vars:
+        * BOLTZMANN_RPC_USERNAME
+        * BOLTZMANN_RPC_PASSWORD
+        * BOLTZMANN_RPC_HOST
+        * BOLTZMANN_RPC_PORT
+    '''
+
+    GENESIS_BLOCK = { #rpc-style format
+        'txid':    ('4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2'
+                    '127b7afdeda33b'),
+        'version':  1,
+        'locktime': 0,
+        'vin': [{
+            "sequence":4294967295,
+            'coinbase': ('04ffff001d0104455468652054696d65732030332f4a6'
+                         '16e2f32303039204368616e63656c6c6f72206f6e2062'
+                         '72696e6b206f66207365636f6e64206261696c6f75742'
+                         '0666f722062616e6b73')
+        }],
+        'vout': [
+            {
+                'value': 50.00000000,
+                'n': 0,
+                'scriptPubKey': {
+                    'asm': ('04678afdb0fe5548271967f1a67130b7105cd6a828'
+                            'e03909a67962e0ea1f61deb649f6bc3f4cef38c4f3'
+                            '5504e51ec112de5c384df7ba0b8d578a4c702b6bf1'
+                            '1d5f OP_CHECKSIG'),
+                    'hex': ('4104678afdb0fe5548271967f1a67130b7105cd6a8'
+                            '28e03909a67962e0ea1f61deb649f6bc3f4cef38c4'
+                            'f35504e51ec112de5c384df7ba0b8d578a4c702b6b'
+                            'f11d5fac'),
+                    'reqSigs': 1,
+                    'type': 'pubkey',
+                    'addresses': ['1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa']
+                }
+            }
+        ]
+    }
+
+    def __init__(self):
+        rpc = dict()
+        rpc['username'] = _get_env('BOLTZMANN_RPC_USERNAME')
+        rpc['password'] = _get_env('BOLTZMANN_RPC_PASSWORD')
+        rpc['host'] = _get_env('BOLTZMANN_RPC_HOST')
+        rpc['port'] = _get_env('BOLTZMANN_RPC_PORT')
+
+        self._con = AuthServiceProxy(
+            "http://{username}:{password}@{host}:{port}".format(**rpc))
+
+
+    def _get_raw_tx(self, txid):
+        """Returns the transaction in raw format."""
+        if txid == ('4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7af'
+                    'deda33b'):
+            raise NoDataAvailableForGenesisBlockError()
+        else:
+            return self._con.getrawtransaction(txid)
+
+
+    def _get_decoded_tx(self, txid):
+        """Gets a human-readable string of the transaction in JSON format."""
+        try:
+            return self._con.getrawtransaction(txid, 1)
+        except NoDataAvailableForGenesisBlockError:
+            #bitcoind won't generate this, but here's what it would look like
+            return self.GENESIS_BLOCK
+
+
+    def _get_block_height(self, txid, rpc_tx=None):
+        """Return the block height at which the transaction was mined.
+
+        Args:
+            txid (str)
+            rpc_tx (Optional[dict]): The data for the specified transaction, if
+                it has already been queried previously from the RPC interface.
+
+        Raises: NoBlockHeightAvailableError: If no block height found.
+        """
+        best_block_hash = self._con.getbestblockhash()
+        best_block = self._con.getblock(best_block_hash)
+        best_block_height = best_block['height']
+
+        if rpc_tx is None:
+            rpc_tx = self._get_decoded_tx(txid)
+
+        #ready for a fun hack? We can compute block height, but only if the
+        #transaction in question has at least one unspent output.
+        for idx, _ in enumerate(rpc_tx['vout']):
+            #Find number of confirmations for this transaction
+            txout = self._con.gettxout(txid, idx)
+            if txout is not None:
+                return best_block_height - txout['confirmations'] + 1
+
+        warn("Could not find number of confirmations in any txo for {0}".format(
+            txid))
+        return -1
+
+    def _get_output_address(self, prev_txid, output_index, prev_tx=None):
+        """Get the address associated with the specified txo.
+
+        Args:
+            prev_txid (str): The id of the tx the output belongs to
+            output_index (int): Index within the outputs corresponding to the
+                output
+            prev_tx (Optional[dict]): The RPC-style prev tx the output belongs
+                to. If not specified, this will be fetched from the RPC
+                interface.
+
+        TODO: This does not properly handle multisig outputs that list multiple
+        addresses per output.
+
+        Raises: PrevOutAddressCannotBeDecodedError
+        """
+        if prev_tx is None:
+            prev_tx = self._get_decoded_tx(prev_txid)
+
+        if('vout' in prev_tx and len(prev_tx['vout']) > output_index and
+           'scriptPubKey' in prev_tx['vout'][output_index]):
+            if 'addresses' not in prev_tx['vout'][output_index]['scriptPubKey']:
+                raise PrevOutAddressCannotBeDecodedError(
+                    "Can't decode address for txo {0}:{1}".format(prev_txid,
+                                                                  output_index))
+            else:
+                return ' '.join(prev_tx['vout'][output_index]['scriptPubKey']['addresses'])
+        else:
+            raise PrevOutAddressCannotBeDecodedError(
+                ("Missing element for vout in get_output_address() with tx "
+                 "id {0} and output index {1}").format(prev_txid, output_index))
+
+    def _rpc_to_bci_input(self, rpc_input):
+        """Convert RPC-style input to BCI-style input.
+
+        Args:
+            rpc_input (dict): The RPC-style representation of an input, found in
+                a transaction's 'vin' array.
+
+        Returns: dict: Representation of input, to be appended to a list
+        attribute called 'inputs'. The input contains these fields:
+            * 'prev_out' (dict)
+                * 'tx_index' (None)
+                * 'txid' (str): previous tx id
+                * 'addr' (str)
+                * 'n' (int): position of txo in prev tx
+                * 'value' (int)
+        """
+        bci_input = dict()
+        bci_input['prev_out'] = dict()
+        bci_input['prev_out']['tx_index'] = None
+        prev_txid = rpc_input['txid']
+        prev_vout_num = rpc_input['vout'] #RPC field is ambiguously named :/
+        bci_input['prev_out']['n'] = prev_vout_num
+
+        prev_tx = self._get_decoded_tx(prev_txid)
+        bci_input['prev_out']['addr'] = self._get_output_address(
+            prev_txid, prev_vout_num, prev_tx)
+        bci_input['prev_out']['script'] = prev_tx['vout'][prev_vout_num]['scriptPubKey']['hex']
+        float_val = prev_tx['vout'][prev_vout_num]['value']
+        bci_input['prev_out']['value'] = _float_to_satoshi(float_val)
+        return bci_input
+
+
+    def get_tx(self, txid):
+        """Get the `Transaction` object for specified hash.
+
+        The `Transaction` constructors expects these fields for a dict:
+            * 'block_height' (int)
+            * 'time' (None)
+            * 'hash' (str)
+            * 'inputs' (List[dict]):
+                * 'prev_out' (dict):
+                    * 'n' (int)
+                    * 'value' (int)
+                    * 'addr' (str)
+                    * 'tx_index' (None)
+            * 'out' (List[dict]): same as 'prev_out'
+        """
+        rpc_style_tx = self._get_decoded_tx(txid)
+        rpc_style_tx['block_height'] = self._get_block_height(txid, rpc_style_tx)
+        rpc_style_tx['time'] = None
+        rpc_style_tx['hash'] = rpc_style_tx['txid']
+
+        rpc_style_tx['inputs'] = list()
+        for txin in rpc_style_tx['vin']:
+            inpt = self._rpc_to_bci_input(txin)
+            rpc_style_tx['inputs'].append(inpt)
+
+        rpc_style_tx['out'] = list()
+        for txout in rpc_style_tx['vout']:
+            outpt = _rpc_to_bci_output(txout)
+            rpc_style_tx['out'].append(outpt)
+
+        return Transaction(rpc_style_tx)
+
+def _get_env(varname):
+    val = os.getenv(varname, None)
+    if val is None:
+        raise MissingRPCConfigurationError('{0} is not set.'.format(varname))
+    return str(val)
+
+def _float_to_satoshi(float_val):
+    """Convert value from BTC (decimal) to satoshis integer.
+    This works fine on my machine in python3:
+        >>> int(round(decimal.Decimal(0.00000001) * decimal.Decimal(1e8)))
+        1
+        >>> int(round(decimal.Decimal(87654321.12345678) * decimal.Decimal(1e8)))
+        8765432112345678
+    """
+    return int(round(decimal.Decimal(float_val) * decimal.Decimal(1e8)))
+
+def _rpc_to_bci_output(rpc_output):
+    """Convert RPC-style otuput to BCI-style output.
+
+    TODO: This does not properly handle multisig outputs that list multiple
+    addresses per output.
+
+    Args:
+        rpc_output (dict): The RPC-style representation of an output, found
+            in a tx's 'vout' array.
+
+    Returns: dict: Representation of output, to be appended to a list
+    attribute called 'out'. The output contains these fields:
+        * 'tx_index' (None)
+        * 'addr' (str)
+        * 'value' (int)
+        * 'n' (int)
+    """
+    bci_output = dict()
+    bci_output['tx_index'] = None
+    bci_output['n'] = rpc_output['n']
+    bci_output['addr'] = ' '.join(rpc_output['scriptPubKey']['addresses'])
+    bci_output['script'] = rpc_output['scriptPubKey']['hex']
+    bci_output['value'] = _float_to_satoshi(rpc_output['value'])
+    return bci_output

--- a/boltzmann/utils/blockchain_data_wrapper.py
+++ b/boltzmann/utils/blockchain_data_wrapper.py
@@ -1,0 +1,16 @@
+"""Abstract class for wrapping various providers of blockchain data."""
+#from boltzmann.utils.transaction import Transaction
+
+class BlockchainDataWrapper(object):
+    """Retrieves data for specified transaction."""
+
+    def get_tx(self, txid):
+        """Returns a `Transaction` object for specified tx hash.
+
+        Args:
+            txid (str): The base58check-encoded transaction id.
+
+        Returns: `Transaction`
+        """
+        raise NotImplementedError("This function should be implemented by"
+                                  "subclasses.")

--- a/boltzmann/utils/transaction.py
+++ b/boltzmann/utils/transaction.py
@@ -13,7 +13,8 @@ class Txo(object):
         if txo is not None:
             self.n = txo['n']
             self.value = txo['value']
-            self.address = txo['addr']
+            # Gets the address or the scriptpubkey (if an address isn't associated to the txo)
+            self.address = txo['addr'] if ('addr' in txo) else txo['script']
             self.tx_idx = txo['tx_index']
             
 

--- a/boltzmann/utils/transaction.py
+++ b/boltzmann/utils/transaction.py
@@ -8,7 +8,16 @@ Inspired from https://github.com/blockchain/api-v1-client-python by https://gith
 class Txo(object):
     '''
     A class storing a few data for a single txo (input or output)
-    '''  
+
+    Attributes:
+        n (int): The position of the TXO in the outputs of the transaction in
+            which it was created.
+        value (int): Value denominated in satoshis.
+        address (str): Bitcoin address associated with the TXO.
+        tx_idx (int): A special identifier assigned to each mined transaction
+            by the Blockchain.info API. Set to `None` if not available. not
+            currently read in this project.
+    '''
     def __init__(self, txo):
         if txo is not None:
             self.n = txo['n']
@@ -16,12 +25,29 @@ class Txo(object):
             # Gets the address or the scriptpubkey (if an address isn't associated to the txo)
             self.address = txo['addr'] if ('addr' in txo) else txo['script']
             self.tx_idx = txo['tx_index']
-            
+
+    def __str__(self):
+        return "{{ 'n': {0}, 'value':{1}, 'address':{2}, 'tx_idx':{3} }}".format(
+            self.n, self.value, self.address, self.tx_idx)
+
+    def __repr__(self):
+        return self.__str__()
+
 
 class Transaction(object):
     '''
     A class storing a few data for a single tx
-    '''  
+
+    Attributes:
+        height (int): 0-based height of block mining tx
+        time (int): Unix timestamp for the time the transaction was received.
+            Not currently used for analysis, and only provided by the
+            Blockchain.info API and not bitcoind's RPC interface. If not
+            available, set to `None`.
+        txid (str): Lower-case hex representation of tx hash
+        inputs (List[`transaction.Txo`])
+        outputs (List[`transaction.Txo`])
+    '''
     def __init__(self, tx):
         height = tx.get('block_height')
         self.height = -1 if (height is None) else height
@@ -29,4 +55,10 @@ class Transaction(object):
         self.txid = tx['hash']
         self.inputs = [Txo(txo_in.get('prev_out')) for txo_in in tx['inputs']]
         self.outputs = [Txo(txo_out) for txo_out in tx['out']]
-        
+
+    def __str__(self):
+        return "{{ 'height': {0}, 'time':{1}, 'txid':{2}, 'inputs':{3}, 'outputs':{4} }}".format(
+            self.height, self.time, self.txid, self.inputs, self.outputs)
+
+    def __repr__(self):
+        return self.__str__()

--- a/boltzmann/utils/transaction.py
+++ b/boltzmann/utils/transaction.py
@@ -17,14 +17,29 @@ class Txo(object):
         tx_idx (int): A special identifier assigned to each mined transaction
             by the Blockchain.info API. Set to `None` if not available. not
             currently read in this project.
+
+    Note that coinbase transactions in the bitcoind-rpc interface and BCI API
+    only contain the 'sequence' and 'script'/'coinbase' fields.
     '''
     def __init__(self, txo):
+        self.n = -1
+        self.value = -1
+        self.address = ''
+        self.tx_idx = -1
+
         if txo is not None:
-            self.n = txo['n']
-            self.value = txo['value']
+            if 'n' in txo:
+                self.n = txo['n']
+            if 'value' in txo:
+                self.value = txo['value']
+
             # Gets the address or the scriptpubkey (if an address isn't associated to the txo)
-            self.address = txo['addr'] if ('addr' in txo) else txo['script']
-            self.tx_idx = txo['tx_index']
+            if 'addr' in txo:
+                self.address = txo['addr']
+            elif 'script' in txo:
+                self.address = txo['script']
+            else:
+                raise ValueError("Could not assign address to txo")
 
     def __str__(self):
         return "{{ 'n': {0}, 'value':{1}, 'address':{2}, 'tx_idx':{3} }}".format(

--- a/boltzmann/utils/tx_processor.py
+++ b/boltzmann/utils/tx_processor.py
@@ -43,8 +43,8 @@ def process_tx(tx, options, max_duration, max_txos, max_cj_intrafees_ratio=0):
         # No need to build this matrix. Every caller should be able to manage that.
         mat_lnk = None
         nb_cmbn = 1
-        txo_ins = post_process_txos(filtered_ins, map_ins)
-        txo_outs = post_process_txos(filtered_outs, map_outs)
+        txo_ins = filtered_ins
+        txo_outs = filtered_outs
     
     else:
         

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 numpy >= 1.8.0
 sortedcontainers
+python-bitcoinrpc

--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,6 @@ setup(
     install_requires=[
         'numpy >= 1.8.0',
         'sortedcontainers',
+        'python-bitcoinrpc'
     ]
 )


### PR DESCRIPTION
coinbase transactions are missing some of the fields we expect. To
avoid crashing (e.g. when iterating through blocks), use some
placeholder values like -1 and empty string.

Sample output:

$ python3 boltzmann/ludwig.py -t d5d27987d2a3dfc724e359870c6644b40e497bdc0589a033220fe15429d88599
DEBUG: Using remote blockchain.info API


--- d5d27987d2a3dfc724e359870c6644b40e497bdc0589a033220fe15429d88599 -------------------------------------
DEBUG: Tx fetched: { 'height': 91842, 'time':1289757588, 'txid':d5d27987d2a3dfc724e359870c6644b40e497bdc0589a033220fe15429d88599, 'inputs':[{ 'n': -1, 'value':-1, 'address':, 'tx_idx':-1 }], 'outputs':[{ 'n': 0, 'value':5000000000, 'address':16va6NxJrMGe5d2LP6wUzuVnzBBoKQZKom, 'tx_idx':-1 }] }
Duration = 2.8e-05

Inputs = []

Outputs = [('16va6NxJrMGe5d2LP6wUzuVnzBBoKQZKom', 5000000000)]

Fees = -5000000000 satoshis

Nb combinations = 1
Tx entropy = 0.000000 bits
